### PR TITLE
fix: prevent suggestions dropdown clipping

### DIFF
--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -105,7 +105,8 @@ html, body {
 
 /* Suggestions dropdown */
 .suggestions-dropdown {
-  position: absolute; top: calc(100% + .25rem); left: 0; z-index: 1000;
+  position: absolute; top: calc(100% + .25rem); left: 0;
+  z-index: 1050; /* sit above surrounding content */
   max-height: 320px; overflow: auto; display: none; /* JS toggles to block */
   border-radius: .75rem; border: 1px solid rgba(255,255,255,.08);
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -49,7 +49,7 @@
 
 <main class="container mt-5">
     <!-- Hero/Search -->
-    <section class="hero glass-card rounded-4 p-4 p-md-5 mb-4 shadow-lg position-relative overflow-hidden">
+    <section class="hero glass-card rounded-4 p-4 p-md-5 mb-4 shadow-lg position-relative">
         <div class="position-absolute gradient-orb orb-1"></div>
         <div class="position-absolute gradient-orb orb-2"></div>
         <div class="text-center mb-4">


### PR DESCRIPTION
## Summary
- remove `overflow-hidden` from hero section so dropdown isn't clipped
- elevate suggestions dropdown with higher z-index

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c2be6c588328b9275f26fbcc6897